### PR TITLE
test(core): achieve 100% line coverage for pathfinding module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,11 @@ module.exports = {
     ecmaFeatures: {
       jsx: true,
     },
+    project: [
+      './packages/core/tsconfig.eslint.json',
+      './packages/ui/tsconfig.json',
+    ],
+    tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint', 'react', 'react-hooks'],
   extends: [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,10 +20,12 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
+    "@vitest/coverage-v8": "^1.6.1",
     "typescript": "^5.3.3",
     "vitest": "^1.3.0"
   }

--- a/packages/core/src/__tests__/algorithms/pathfinding.test.ts
+++ b/packages/core/src/__tests__/algorithms/pathfinding.test.ts
@@ -18,13 +18,11 @@ describe("pathfinding module", () => {
                 expect(Array.isArray(edges)).toBe(true);
 
                 for(const edge of edges) {
-                    expect(edge).toEqual(
-                        expect.objectContaining({
-                            nodeId: expect.any(String),
-                            edgeId: expect.any(String),
-                            weight: expect.any(Number)
-                        })
-                    );
+                    
+                    expect(typeof edge.nodeId).toBe("string");
+                    expect(typeof edge.edgeId).toBe("string");
+                    expect(typeof edge.weight).toBe("number");
+
                     expect(edge.weight).toBeGreaterThanOrEqual(0);
                     expect(edge.weight).toBeLessThanOrEqual(1);
                 }
@@ -157,12 +155,10 @@ describe("pathfinding module", () => {
                 expect(fixture.shortestPaths).toHaveLength(0);
             }
             else{
-                expect(fixture.shortestPaths).toContainEqual(
-                    expect.objectContaining({
-                        path: result.path,
-                        distance: expect.closeTo(result.distance, 6)
-                    })
-                );
+                const matchingPathResult = fixture.shortestPaths.find(p => JSON.stringify(p.path) === JSON.stringify(result.path));
+
+                expect(matchingPathResult).toBeDefined();
+                expect(matchingPathResult?.distance).toBeCloseTo(result.distance, 6);
             }
         });
     });

--- a/packages/core/src/__tests__/algorithms/pathfinding.test.ts
+++ b/packages/core/src/__tests__/algorithms/pathfinding.test.ts
@@ -1,28 +1,120 @@
 import { describe, expect, test } from 'vitest';
-import type { GraphNode, GraphEdge, PathResult } from "../../types/index.ts";
-import { buildAdjacency } from "../../algorithms/pathfinding.js";
+import { buildAdjacency, bfsShortestPath, dijkstraShortestPath } from "../../algorithms/pathfinding.js";
 import * as fixtures from "../testUtils/fixtures/index.js";
 
-describe("pathfinding", () => {
+describe("pathfinding module", () => {
 
     describe("buildAdjacency function", () => {
 
-        test("Builds Adjacency list for simple graph", () => {
+        test("returns a valid adjacency map structure", () => {
 
-            const result = buildAdjacency(fixtures.nodeSet1, fixtures.edgeSet1);
+            const result = buildAdjacency(fixtures.adjacency.general.nodes, fixtures.adjacency.general.edges);
 
-            expect(result).toEqual(fixtures.adjList1);
+            expect(result).toBeInstanceOf(Map);
+
+            for(const [node, edges] of result) {
+
+                expect(node).toEqual(expect.any(String));
+                expect(Array.isArray(edges)).toBe(true);
+
+                for(const edge of edges) {
+                    expect(edge).toEqual(
+                        expect.objectContaining({
+                            nodeId: expect.any(String),
+                            edgeId: expect.any(String),
+                            weight: expect.any(Number)
+                        })
+                    );
+                    expect(edge.weight).toBeGreaterThanOrEqual(0);
+                    expect(edge.weight).toBeLessThanOrEqual(1);
+                }
+            }
+
+            expect(result.size).toBe(fixtures.adjacency.general.nodes.length);
+        });
+
+        test.each([
+            ["directional edges", fixtures.adjacency.directional],
+            ["bidirectional edges", fixtures.adjacency.biDirectional],
+            ["missing weight", fixtures.adjacency.weight],
+            ["zero edges scenario", fixtures.adjacency.noEdges],
+            ["unconnected nodes", fixtures.adjacency.unConnectedNode],
+            ["unknown source nodes", fixtures.adjacency.unknownSource],
+            ["unknown target nodes", fixtures.adjacency.unknownTarget],
+            ["duplicate edges", fixtures.adjacency.duplicateEdge],
+        ])("handles %s", (_, fixture) => {
+
+            const result = buildAdjacency(fixture.nodes, fixture.edges);
+            expect(result).toEqual(fixture.adjacencyList);
+        });
+    });
+
+    describe("bfsShortestPath function", () => {
+
+        test("returns valid result structure", () => {
+
+            const result = bfsShortestPath(
+                fixtures.graphShortestPath.general.nodes, 
+                fixtures.graphShortestPath.general.edges, 
+                fixtures.graphShortestPath.general.sourceId, 
+                fixtures.graphShortestPath.general.targetId
+            );
+    
+            if(result != null){
+                expect(result).toHaveProperty("path");
+                expect(result).toHaveProperty("distance");
+
+                expect(Array.isArray(result.path)).toBe(true);
+                expect(Number.isInteger(result.distance)).toBe(true);
+
+                for(const node of result.path) {
+                    expect(node).toEqual(expect.any(String));
+                }
+            }
+        });
+
+        test.each([
+            ["single node graph", fixtures.graphShortestPath.singleNode],
+        ])("handles %s", (_, fixture) => {
+
+            const result = bfsShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
+            expect(result).toEqual(fixture.expectedPath);
         });
 
     });
 
-    // describe("bfsShortestPath function", () => {
+    describe("dijkstraShortestPath function", () => {
 
-    // });
+        test("returns valid result structure", () => {
 
-    // describe("dijkstraShortestPath function", () => {
+            const result = bfsShortestPath(
+                fixtures.graphShortestPath.general.nodes, 
+                fixtures.graphShortestPath.general.edges, 
+                fixtures.graphShortestPath.general.sourceId, 
+                fixtures.graphShortestPath.general.targetId
+            );
+    
+            if(result != null){
+                expect(result).toHaveProperty("path");
+                expect(result).toHaveProperty("distance");
 
-    // });
+                expect(Array.isArray(result.path)).toBe(true);
+                expect(Number.isInteger(result.distance)).toBe(true);
+
+                for(const node of result.path) {
+                    expect(node).toEqual(expect.any(String));
+                }
+            }
+        });
+
+        test.each([
+            ["single node graph", fixtures.graphShortestPath.singleNode],
+        ])("handles %s", (_, fixture) => {
+
+            const result = dijkstraShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
+            expect(result).toEqual(fixture.expectedPath);
+        });
+    });
 
     // describe("findAllPaths function", () => {
 

--- a/packages/core/src/__tests__/algorithms/pathfinding.test.ts
+++ b/packages/core/src/__tests__/algorithms/pathfinding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { buildAdjacency, bfsShortestPath, dijkstraShortestPath } from "../../algorithms/pathfinding.js";
+import { buildAdjacency, bfsShortestPath, dijkstraShortestPath, findAllPaths, reachableNodes, betweennessCentrality } from "../../algorithms/pathfinding.js";
 import * as fixtures from "../testUtils/fixtures/index.js";
 
 describe("pathfinding module", () => {
@@ -34,18 +34,26 @@ describe("pathfinding module", () => {
         });
 
         test.each([
-            ["directional edges", fixtures.adjacency.directional],
-            ["bidirectional edges", fixtures.adjacency.biDirectional],
-            ["missing weight", fixtures.adjacency.weight],
+            ["missing weight", fixtures.adjacency.missingWeight],
             ["zero edges scenario", fixtures.adjacency.noEdges],
             ["unconnected nodes", fixtures.adjacency.unConnectedNode],
-            ["unknown source nodes", fixtures.adjacency.unknownSource],
-            ["unknown target nodes", fixtures.adjacency.unknownTarget],
-            ["duplicate edges", fixtures.adjacency.duplicateEdge],
+            ["directional edges with explicit weight", fixtures.adjacency.directionalWithWeight],
+            ["directional edges with default weight", fixtures.adjacency.directionalWithoutWeight],
+            ["bidirectional edges with explicit weight", fixtures.adjacency.biDirectionalWithWeight],
+            ["bidirectional edges with default weight", fixtures.adjacency.biDirectionalWithoutWeight],
+            ["duplicate edges", fixtures.adjacency.duplicateEdges],
         ])("handles %s", (_, fixture) => {
 
             const result = buildAdjacency(fixture.nodes, fixture.edges);
-            expect(result).toEqual(fixture.adjacencyList);
+
+            expect(result.size).toBe(fixture.adjacencyList.size);
+
+            for(const [node, edges] of fixture.adjacencyList){
+                expect(result.has(node)).toBe(true);
+
+                expect(result.get(node)).toHaveLength(edges.length);
+                expect(result.get(node)).toEqual(expect.arrayContaining(edges));
+            }
         });
     });
 
@@ -75,8 +83,11 @@ describe("pathfinding module", () => {
 
         test.each([
             ["single node graph", fixtures.bfsShortestPath.singleNode],
+            ["no edges", fixtures.bfsShortestPath.noEdges],
+            ["self loop", fixtures.bfsShortestPath.selfLoop],
             ["simple tree pattern", fixtures.bfsShortestPath.treePattern],
             ["multiple paths", fixtures.bfsShortestPath.multiplePaths],
+            ["multiple shortest paths", fixtures.bfsShortestPath.multipleShortestPaths],
             ["cyclic graph", fixtures.bfsShortestPath.cyclicGraph],
             ["no path exists", fixtures.bfsShortestPath.noPath],
             ["disconnected components", fixtures.bfsShortestPath.disconnectedComponents],
@@ -88,10 +99,14 @@ describe("pathfinding module", () => {
         ])("handles %s", (_, fixture) => {
 
             const result = bfsShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
-            expect(result).toEqual(fixture.expectedPath);
-        });
 
-        // Right now Dijsktra algo function does not handle negative edges, which is extremely important edge case.
+            if(result === null){
+                expect(fixture.shortestPaths).toHaveLength(0);
+            }
+            else{
+                expect(fixture.shortestPaths).toContainEqual(result);
+            }
+        });
 
     });
 
@@ -121,8 +136,11 @@ describe("pathfinding module", () => {
 
         test.each([
             ["single node graph", fixtures.dijkstra.singleNode],
+            ["no edges", fixtures.dijkstra.noEdges],
+            ["self loop", fixtures.dijkstra.selfLoop],
             ["simple tree pattern", fixtures.dijkstra.treePattern],
             ["multiple paths", fixtures.dijkstra.multiplePaths],
+            ["multiple shortest paths", fixtures.dijkstra.multipleShortestPaths],
             ["cyclic graph", fixtures.dijkstra.cyclicGraph],
             ["no path exists", fixtures.dijkstra.noPath],
             ["disconnected components", fixtures.dijkstra.disconnectedComponents],
@@ -134,27 +152,146 @@ describe("pathfinding module", () => {
         ])("handles %s", (_, fixture) => {
 
             const result = dijkstraShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
-            expect(result).toEqual(
-                fixture.expectedPath === null
-                ? null
-                : {
-                    path: fixture.expectedPath.path,
-                    distance: expect.closeTo(fixture.expectedPath.distance, 6)
-                }
-            );
+            
+            if(result === null){
+                expect(fixture.shortestPaths).toHaveLength(0);
+            }
+            else{
+                expect(fixture.shortestPaths).toContainEqual(
+                    expect.objectContaining({
+                        path: result.path,
+                        distance: expect.closeTo(result.distance, 6)
+                    })
+                );
+            }
         });
     });
 
-    // describe("findAllPaths function", () => {
+    describe("findAllPaths function", () => {
 
-    // });
+        test("returns valid result structure", () => {
+            const result = findAllPaths(
+                fixtures.allPaths.general.nodes,
+                fixtures.allPaths.general.edges,
+                fixtures.allPaths.general.sourceId,
+                fixtures.allPaths.general.targetId,
+                fixtures.allPaths.general.maxPaths,
+                fixtures.allPaths.general.maxDepth,
+            );
+            expect(Array.isArray(result)).toBe(true);
 
-    // describe("reachableNodes function", () => {
+            for(const element of result){
+                expect(element).toHaveProperty("path");
+                expect(element).toHaveProperty("distance");
 
-    // });
+                expect(Array.isArray(element.path)).toBe(true);
+                expect(Number.isInteger(element.distance)).toBe(true);
+                expect(element.distance).toBe(element.path.length - 1);
+
+                for(const node of element.path){
+                    expect(node).toEqual(expect.any(String));
+                }
+            }
+        });
+
+        test.each([
+            ["single node graph", fixtures.allPaths.singleNode],
+            ["no edges", fixtures.allPaths.noEdges],
+            ["self loop", fixtures.allPaths.selfLoop],
+            ["source equals target", fixtures.allPaths.sourceEqualsTarget],
+            ["tree pattern", fixtures.allPaths.treePattern],
+            ["multiple paths", fixtures.allPaths.multiplePaths],
+            ["no path", fixtures.allPaths.noPath],
+            ["disconnected components", fixtures.allPaths.disconnectedComponents],
+            ["missing target", fixtures.allPaths.missingTarget],
+            ["unknown source", fixtures.allPaths.unknownSource],
+            ["bidirectional edges", fixtures.allPaths.bidirectionalEdges],
+            ["duplicate edges", fixtures.allPaths.duplicateEdges],
+            ["large depths exceeding max depth limit", fixtures.allPaths.largeDepth],
+            ["availabe path count exceeding max path limit", fixtures.allPaths.highPathCount],
+        ])("handles %s", (_, fixture) => {
+
+            const result = findAllPaths(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId, fixture.maxPaths, fixture.maxDepth);
+            
+            expect(Array.isArray(result)).toBe(true);
+            expect(result).toHaveLength(fixture.expectedPaths.length);
+            expect(result).toEqual(expect.arrayContaining(fixture.expectedPaths));
+        });
+    });
+
+    describe("reachableNodes function", () => {
+
+        test("returns valid result structure", () => {
+            const result = reachableNodes(
+                fixtures.reachableNodes.general.nodes,
+                fixtures.reachableNodes.general.edges,
+                fixtures.reachableNodes.general.sourceId,
+            );
+
+            expect(Array.isArray(result)).toBe(true);
+            for(const node of result){
+                expect(node).toEqual(expect.any(String));
+            }
+        });
+
+        test.each([
+            ["single node", fixtures.reachableNodes.singleNode],
+            ["no edges", fixtures.reachableNodes.noEdges],
+            ["self loop", fixtures.reachableNodes.selfLoop],
+            ["tree pattern", fixtures.reachableNodes.treePattern],
+            ["disconnected components", fixtures.reachableNodes.disconnectedComponents],
+            ["unknown source", fixtures.reachableNodes.unknownSource],
+            ["bidirectional edges", fixtures.reachableNodes.bidirectionalEdges],
+            ["source is absent from nodes but present in edges", fixtures.reachableNodes.absentSourceFromNodes],
+            ["duplicate edges", fixtures.reachableNodes.duplicateEdges],
+            ["cyclic graph", fixtures.reachableNodes.cyclicGraph],
+        ])("handles %s", (_, fixture) => {
+
+            const result = reachableNodes(fixture.nodes, fixture.edges, fixture.sourceId);
+
+            expect(result).not.toContain(fixture.sourceId);
+            expect(result).toHaveLength(fixture.expectedNodes.length);
+            expect(result).toEqual(expect.arrayContaining(fixture.expectedNodes));
+        });
+    });
     
-    // describe("betweennessCentrality function", () => {
+    describe("betweennessCentrality function", () => {
 
-    // });
+        test("returns valid result structure", () => {
+            const result = betweennessCentrality(
+                fixtures.centrality.general.nodes,
+                fixtures.centrality.general.edges,
+            );
 
+            expect(result).toBeInstanceOf(Map);
+
+            for(const [node, normalizedScore] of result){
+                expect(node).toEqual(expect.any(String));
+                expect(normalizedScore).toEqual(expect.any(Number));
+            }
+        });
+
+        test.each([
+            ["single node", fixtures.centrality.singleNode],
+            ["no edges", fixtures.centrality.noEdges],
+            ["no intermediate nodes", fixtures.centrality.noIntermediateNodes],
+            ["self loop", fixtures.centrality.selfLoop],
+            ["tree pattern", fixtures.centrality.treePattern],
+            ["multiple shortest paths", fixtures.centrality.multipleShortestPaths],
+            ["disconnected components", fixtures.centrality.disconnectedComponents],
+            ["bidirectional edges", fixtures.centrality.bidirectionalEdges],
+            ["duplicate edges", fixtures.centrality.duplicateEdges],
+            ["wide branching graph", fixtures.centrality.wideBranchingGraph],
+        ])("handles %s", (_, fixture) => {
+
+            const result = betweennessCentrality(fixture.nodes, fixture.edges);
+
+            expect(result.size).toBe(fixture.expectedResult.size);
+
+            for(const [node, normalizedScore] of fixture.expectedResult){
+                expect(result.has(node)).toBe(true);
+                expect(result.get(node)).toBeCloseTo(normalizedScore, 6);
+            }
+        });
+    });
 });

--- a/packages/core/src/__tests__/algorithms/pathfinding.test.ts
+++ b/packages/core/src/__tests__/algorithms/pathfinding.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import type { GraphNode, GraphEdge, PathResult } from "../../types/index.ts";
+import { buildAdjacency } from "../../algorithms/pathfinding.js";
+import * as fixtures from "../testUtils/fixtures/index.js";
+
+describe("pathfinding", () => {
+
+    describe("buildAdjacency function", () => {
+
+        test("Builds Adjacency list for simple graph", () => {
+
+            const result = buildAdjacency(fixtures.nodeSet1, fixtures.edgeSet1);
+
+            expect(result).toEqual(fixtures.adjList1);
+        });
+
+    });
+
+    // describe("bfsShortestPath function", () => {
+
+    // });
+
+    // describe("dijkstraShortestPath function", () => {
+
+    // });
+
+    // describe("findAllPaths function", () => {
+
+    // });
+
+    // describe("reachableNodes function", () => {
+
+    // });
+    
+    // describe("betweennessCentrality function", () => {
+
+    // });
+
+});

--- a/packages/core/src/__tests__/algorithms/pathfinding.test.ts
+++ b/packages/core/src/__tests__/algorithms/pathfinding.test.ts
@@ -54,10 +54,10 @@ describe("pathfinding module", () => {
         test("returns valid result structure", () => {
 
             const result = bfsShortestPath(
-                fixtures.graphShortestPath.general.nodes, 
-                fixtures.graphShortestPath.general.edges, 
-                fixtures.graphShortestPath.general.sourceId, 
-                fixtures.graphShortestPath.general.targetId
+                fixtures.bfsShortestPath.general.nodes, 
+                fixtures.bfsShortestPath.general.edges, 
+                fixtures.bfsShortestPath.general.sourceId, 
+                fixtures.bfsShortestPath.general.targetId
             );
     
             if(result != null){
@@ -74,12 +74,24 @@ describe("pathfinding module", () => {
         });
 
         test.each([
-            ["single node graph", fixtures.graphShortestPath.singleNode],
+            ["single node graph", fixtures.bfsShortestPath.singleNode],
+            ["simple tree pattern", fixtures.bfsShortestPath.treePattern],
+            ["multiple paths", fixtures.bfsShortestPath.multiplePaths],
+            ["cyclic graph", fixtures.bfsShortestPath.cyclicGraph],
+            ["no path exists", fixtures.bfsShortestPath.noPath],
+            ["disconnected components", fixtures.bfsShortestPath.disconnectedComponents],
+            ["missing target", fixtures.bfsShortestPath.missingTarget],
+            ["unknown source", fixtures.bfsShortestPath.unknownSource],
+            ["bidirectional edges", fixtures.bfsShortestPath.bidirectionalEdges],
+            ["duplicate edges", fixtures.bfsShortestPath.duplicateEdges],
+            ["wide branching graph", fixtures.bfsShortestPath.wideBranchingGraph],
         ])("handles %s", (_, fixture) => {
 
             const result = bfsShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
             expect(result).toEqual(fixture.expectedPath);
         });
+
+        // Right now Dijsktra algo function does not handle negative edges, which is extremely important edge case.
 
     });
 
@@ -87,11 +99,11 @@ describe("pathfinding module", () => {
 
         test("returns valid result structure", () => {
 
-            const result = bfsShortestPath(
-                fixtures.graphShortestPath.general.nodes, 
-                fixtures.graphShortestPath.general.edges, 
-                fixtures.graphShortestPath.general.sourceId, 
-                fixtures.graphShortestPath.general.targetId
+            const result = dijkstraShortestPath(
+                fixtures.dijkstra.general.nodes, 
+                fixtures.dijkstra.general.edges, 
+                fixtures.dijkstra.general.sourceId, 
+                fixtures.dijkstra.general.targetId
             );
     
             if(result != null){
@@ -99,7 +111,7 @@ describe("pathfinding module", () => {
                 expect(result).toHaveProperty("distance");
 
                 expect(Array.isArray(result.path)).toBe(true);
-                expect(Number.isInteger(result.distance)).toBe(true);
+                expect(result.distance).toEqual(expect.any(Number));
 
                 for(const node of result.path) {
                     expect(node).toEqual(expect.any(String));
@@ -108,11 +120,28 @@ describe("pathfinding module", () => {
         });
 
         test.each([
-            ["single node graph", fixtures.graphShortestPath.singleNode],
+            ["single node graph", fixtures.dijkstra.singleNode],
+            ["simple tree pattern", fixtures.dijkstra.treePattern],
+            ["multiple paths", fixtures.dijkstra.multiplePaths],
+            ["cyclic graph", fixtures.dijkstra.cyclicGraph],
+            ["no path exists", fixtures.dijkstra.noPath],
+            ["disconnected components", fixtures.dijkstra.disconnectedComponents],
+            ["missing target", fixtures.dijkstra.missingTarget],
+            ["unknown source", fixtures.dijkstra.unknownSource],
+            ["bidirectional edges", fixtures.dijkstra.bidirectionalEdges],
+            ["duplicate edges", fixtures.dijkstra.duplicateEdges],
+            ["wide branching graph", fixtures.dijkstra.wideBranchingGraph],
         ])("handles %s", (_, fixture) => {
 
             const result = dijkstraShortestPath(fixture.nodes, fixture.edges, fixture.sourceId, fixture.targetId);
-            expect(result).toEqual(fixture.expectedPath);
+            expect(result).toEqual(
+                fixture.expectedPath === null
+                ? null
+                : {
+                    path: fixture.expectedPath.path,
+                    distance: expect.closeTo(fixture.expectedPath.distance, 6)
+                }
+            );
         });
     });
 

--- a/packages/core/src/__tests__/testUtils/factories/graphFactory.ts
+++ b/packages/core/src/__tests__/testUtils/factories/graphFactory.ts
@@ -1,0 +1,25 @@
+import type { GraphNode, GraphEdge } from "../../../types/index.ts";
+
+export function createNode(nodeId: string): GraphNode {
+    const node: GraphNode = {
+        id: nodeId,
+        type: "resource",
+        label: nodeId,
+        position: {x: 0, y: 0},
+        createdAt: 0,
+        updatedAt: 0
+    };
+    return node;
+}
+
+export function createEdge(edgeId: string, source: string, target: string, weight: number, bidirectional: boolean): GraphEdge {
+    const edge: GraphEdge = {
+        id: edgeId,
+        type: "custom", 
+        source,
+        target,
+        weight,
+        bidirectional
+    };
+    return edge;
+}

--- a/packages/core/src/__tests__/testUtils/factories/graphFactory.ts
+++ b/packages/core/src/__tests__/testUtils/factories/graphFactory.ts
@@ -12,7 +12,7 @@ export function createNode(nodeId: string): GraphNode {
     return node;
 }
 
-export function createEdge(edgeId: string, source: string, target: string, weight: number, bidirectional: boolean): GraphEdge {
+export function createEdge(edgeId: string, source: string, target: string, bidirectional: boolean, weight: number = 1): GraphEdge {
     const edge: GraphEdge = {
         id: edgeId,
         type: "custom", 

--- a/packages/core/src/__tests__/testUtils/factories/index.ts
+++ b/packages/core/src/__tests__/testUtils/factories/index.ts
@@ -1,0 +1,2 @@
+
+export * from "./graphFactory";

--- a/packages/core/src/__tests__/testUtils/fixtures/adjacency.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/adjacency.fixtures.ts
@@ -1,7 +1,7 @@
 import { createNode, createEdge } from "../factories/index";
-import type { AdjacencyFixtureBody, GraphShortestPathFixtureBody } from "../types";
+import type { AdjacencyFixtureBody } from "../types";
 
-export const adjacency: Record<string, AdjacencyFixtureBody> = {
+export const adjacency = {
     general: {
         nodes: [
             createNode("n1"),
@@ -145,39 +145,4 @@ export const adjacency: Record<string, AdjacencyFixtureBody> = {
             ]],
         ])
     }
-};
-
-export const graphShortestPath: Record<string, GraphShortestPathFixtureBody> = {
-    general: {
-        nodes: [
-            createNode("n1"),
-            createNode("n2"),
-            createNode("n3"),
-            createNode("n4"),
-        ],
-        edges: [
-            createEdge("e1", "n1", "n2", false),
-            createEdge("e2", "n2", "n3", false),
-            createEdge("e3", "n3", "n1", false),
-            createEdge("e4", "n3", "n4", false),
-        ],
-        sourceId: "n1",
-        targetId: "n3",
-        expectedPath: {
-            path: ["n1", "n2", "n3"],
-            distance: 2
-        }
-    },
-    singleNode: {
-        nodes: [
-            createNode("n1"),
-        ],
-        edges: [],
-        sourceId: "n1",
-        targetId: "n1",
-        expectedPath: {
-            path: ["n1"],
-            distance: 0
-        }
-    },
-};
+} satisfies Record<string, AdjacencyFixtureBody>;;

--- a/packages/core/src/__tests__/testUtils/fixtures/adjacency.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/adjacency.fixtures.ts
@@ -7,11 +7,13 @@ export const adjacency = {
             createNode("n1"),
             createNode("n2"),
             createNode("n3"),
+            createNode("n4"),
         ],
         edges: [
             createEdge("e1", "n1", "n2", true, 0.5),
             createEdge("e2", "n2", "n3", false, 0.5),
-            createEdge("e3", "n1", "n3", false, 0.5),
+            createEdge("e3", "n1", "n3", false),
+            createEdge("e4", "n4", "n3", true),
         ],
         adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
             ["n1", [
@@ -23,45 +25,14 @@ export const adjacency = {
                 {nodeId: "n3", edgeId: "e2", weight: 0.5},
             ]],
             ["n3", [
-    
+                {nodeId: "n4", edgeId: "e4", weight: 1},
+            ]],
+            ["n4", [
+                {nodeId: "n3", edgeId: "e4", weight: 1},
             ]]
         ])
     },
-    directional: {
-        nodes: [
-            createNode("n1"),
-            createNode("n2"),
-        ],
-        edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-        ],
-        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
-            ["n1", [
-                {nodeId: "n2", edgeId: "e1", weight: 0.5},
-            ]],
-            ["n2", [
-    
-            ]],
-        ])
-    },
-    biDirectional: {
-        nodes: [
-            createNode("n1"),
-            createNode("n2"),
-        ],
-        edges: [
-            createEdge("e1", "n1", "n2", true, 0.5),
-        ],
-        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
-            ["n1", [
-                {nodeId: "n2", edgeId: "e1", weight: 0.5},
-            ]],
-            ["n2", [
-                {nodeId: "n1", edgeId: "e1", weight: 0.5},
-            ]],
-        ])
-    },
-    weight: {
+    missingWeight: {
         nodes: [
             createNode("n1"),
             createNode("n2"),
@@ -92,56 +63,117 @@ export const adjacency = {
     unConnectedNode: {
         nodes: [
             createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
         ],
         edges: [],
         adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
-            ["n1", []]
-        ])
-    },
-    unknownTarget: {
-        nodes: [
-            createNode("n1"),
-            createNode("n2"),
-        ],
-        edges: [
-            createEdge("e1", "n1", "n3", false, 0.5),
-        ],
-        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
-            ["n1", [
-                {nodeId: "n3", edgeId: "e1", weight: 0.5},
-            ]],
-            ["n2", []],
-        ])
-    },
-    unknownSource: {
-        nodes: [
-            createNode("n1"),
-            createNode("n2"),
-        ],
-        edges: [
-            createEdge("e1", "n3", "n1", false, 0.5),
-        ],
-        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
             ["n1", []],
             ["n2", []],
+            ["n3", []],
         ])
     },
-    duplicateEdge: {
+    directionalWithWeight: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 0.5},
+            ]],
+            ["n2", [
+    
+            ]]
+        ])
+    },
+    directionalWithoutWeight: {
         nodes: [
             createNode("n1"),
             createNode("n2"),
         ],
         edges: [
             createEdge("e1", "n1", "n2", false),
-            createEdge("e1", "n1", "n2", false),
         ],
         adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
             ["n1", [
-                {nodeId: "n2", edgeId: "e1", weight: 1},
                 {nodeId: "n2", edgeId: "e1", weight: 1},
             ]],
             ["n2", [
     
+            ]]
+        ])
+    },
+    biDirectionalWithWeight: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 0.5},
+            ]],
+            ["n2", [
+                {nodeId: "n1", edgeId: "e1", weight: 0.5},
+            ]],
+        ])
+    },
+    biDirectionalWithoutWeight: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+            ]],
+            ["n2", [
+                {nodeId: "n1", edgeId: "e1", weight: 1},
+            ]],
+        ])
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e3", "n3", "n2", false, 0.5),
+            createEdge("e4", "n3", "n4", true, 0.5),
+            createEdge("e5", "n4", "n1", true),
+            createEdge("e5", "n4", "n1", true),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+                {nodeId: "n4", edgeId: "e5", weight: 1},
+                {nodeId: "n4", edgeId: "e5", weight: 1},
+            ]],
+            ["n2", [
+    
+            ]],
+            ["n3", [
+                {nodeId: "n2", edgeId: "e3", weight: 0.5},
+                {nodeId: "n4", edgeId: "e4", weight: 0.5},
+            ]],
+            ["n4", [
+                {nodeId: "n1", edgeId: "e5", weight: 1},
+                {nodeId: "n1", edgeId: "e5", weight: 1},
+                {nodeId: "n3", edgeId: "e4", weight: 0.5},
             ]],
         ])
     }

--- a/packages/core/src/__tests__/testUtils/fixtures/allPaths.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/allPaths.fixtures.ts
@@ -1,0 +1,326 @@
+import { createNode, createEdge } from "../factories/index";
+import type { AllPathsFixtureBody } from "../types";
+
+export const allPaths = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.1),
+            createEdge("e2", "n2", "n3", true, 0.2),
+            createEdge("e3", "n4", "n3", false, 0.3),
+            createEdge("e4", "n2", "n4", false, 0.4),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n2", "n3"], distance: 2},
+            {path: ["n1", "n2", "n4", "n3"], distance: 3},
+        ]
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n1",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n2",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    selfLoop: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n1", true, 0.5),
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n2",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n2"], distance: 1},
+        ]
+    },
+    sourceEqualsTarget: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n1",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    treePattern: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e2", "n2", "n5", false, 0.6),
+            createEdge("e4", "n3", "n4", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n2", "n3", "n4"], distance: 3},
+        ]
+    },
+    multiplePaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n4", "n1", false, 0.5),
+            createEdge("e5", "n1", "n5", false, 0.6),
+            createEdge("e5", "n2", "n5", false, 0.7),
+            createEdge("e5", "n3", "n5", false, 0.8),
+            createEdge("e5", "n4", "n5", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n5",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n5"], distance: 1},
+            {path: ["n1", "n2", "n5"], distance: 2},
+            {path: ["n1", "n2", "n3", "n5"], distance: 3},
+            {path: ["n1", "n2", "n3", "n4", "n5"], distance: 4},
+        ]
+    },
+    noPath: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n4", "n3", false, 0.8),
+            createEdge("e5", "n4", "n2", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    disconnectedComponents: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    missingTarget: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    unknownSource: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+        ],
+        sourceId: "n4",
+        targetId: "n1",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: []
+    },
+    bidirectionalEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", true, 0.2),
+            createEdge("e4", "n4", "n1", true, 0.5),
+            createEdge("e5", "n1", "n5", false, 0.6),
+            createEdge("e5", "n2", "n5", false, 0.7),
+            createEdge("e5", "n3", "n5", false, 0.8),
+            createEdge("e5", "n4", "n5", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n5",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n5"], distance: 1},
+            {path: ["n1", "n2", "n5"], distance: 2},
+            {path: ["n1", "n2", "n3", "n5"], distance: 3},
+            {path: ["n1", "n2", "n3", "n4", "n5"], distance: 4},
+            {path: ["n1", "n4", "n5"], distance: 2},
+            {path: ["n1", "n4", "n3", "n5"], distance: 3},
+        ]
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n3", "n4"], distance: 2},
+            {path: ["n1", "n3", "n4"], distance: 2},
+            {path: ["n1", "n2", "n3", "n4"], distance: 3},
+        ]
+    },
+    largeDepth: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n2", "n4", false, 0.5),
+            createEdge("e5", "n6", "n5", false, 0.6),
+            createEdge("e6", "n3", "n5", true, 0.7),
+            createEdge("e7", "n1", "n6", false, 0.8),
+            createEdge("e8", "n6", "n3", false, 0.9),
+            createEdge("e9", "n5", "n7", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 10,
+        maxDepth: 3,
+        expectedPaths: [
+            {path: ["n1", "n2", "n4"], distance: 2},
+            {path: ["n1", "n2", "n3", "n4"], distance: 3},
+            {path: ["n1", "n6", "n3", "n4"], distance: 3},
+        ]
+    },
+    highPathCount: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n2", "n4", false, 0.5),
+            createEdge("e5", "n6", "n5", false, 0.6),
+            createEdge("e6", "n3", "n5", true, 0.7),
+            createEdge("e7", "n1", "n6", false, 0.8),
+            createEdge("e8", "n6", "n3", false, 0.9),
+            createEdge("e9", "n5", "n7", false, 0.9),
+            createEdge("e10", "n7", "n4", false, 1.0),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        maxPaths: 4,
+        maxDepth: 20,
+        expectedPaths: [
+            {path: ["n1", "n2", "n4"], distance: 2},
+            {path: ["n1", "n2", "n3", "n4"], distance: 3},
+            {path: ["n1", "n6", "n5", "n3", "n4"], distance: 4},
+            {path: ["n1", "n2", "n3", "n5", "n7", "n4"], distance: 5},
+        ]
+    },
+} satisfies Record<string, AllPathsFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/bfsShortestPath.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/bfsShortestPath.fixtures.ts
@@ -17,10 +17,9 @@ export const bfsShortestPath = {
         ],
         sourceId: "n1",
         targetId: "n3",
-        expectedPath: {
-            path: ["n1", "n2", "n3"],
-            distance: 2
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3"], distance: 2}
+        ]
     },
     singleNode: {
         nodes: [
@@ -29,10 +28,34 @@ export const bfsShortestPath = {
         edges: [],
         sourceId: "n1",
         targetId: "n1",
-        expectedPath: {
-            path: ["n1"],
-            distance: 0
-        }
+        shortestPaths: [
+            {path: ["n1"], distance: 0}
+        ]
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n2",
+        shortestPaths: []
+    },
+    selfLoop: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n1", false, 0.5),
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n2",
+        shortestPaths: [
+            {path: ["n1", "n2"], distance: 1}
+        ]
     },
     treePattern: {
         nodes: [
@@ -50,10 +73,9 @@ export const bfsShortestPath = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n2", "n3", "n4"],
-            distance: 3
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3", "n4"], distance: 3}
+        ]
     },
     multiplePaths: {
         nodes: [
@@ -73,10 +95,33 @@ export const bfsShortestPath = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n5", "n4"],
-            distance: 2
-        }
+        shortestPaths: [
+            {path: ["n1", "n5", "n4"], distance: 2},
+        ]
+    },
+    multipleShortestPaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n1", "n5", false, 0.5),
+            createEdge("e5", "n5", "n4", false, 0.8),
+            createEdge("e6", "n5", "n2", false, 0.0),
+            createEdge("e7", "n1", "n3", false, 0.0),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        shortestPaths: [
+            {path: ["n1", "n5", "n4"], distance: 2},
+            {path: ["n1", "n3", "n4"], distance: 2},
+        ]
     },
     cyclicGraph: {
         nodes: [
@@ -94,10 +139,9 @@ export const bfsShortestPath = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n2", "n3", "n4"],
-            distance: 3
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3", "n4"], distance: 3}
+        ]
     },
     noPath: {
         nodes: [
@@ -107,15 +151,15 @@ export const bfsShortestPath = {
             createNode("n4"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-            createEdge("e2", "n2", "n3", false, 0.6),
-            createEdge("e3", "n3", "n1", false, 0.7),
-            createEdge("e4", "n4", "n3", false, 0.8),
-            createEdge("e5", "n4", "n2", false, 0.9),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n2", "n3", false),
+            createEdge("e3", "n3", "n1", false),
+            createEdge("e4", "n4", "n3", false),
+            createEdge("e5", "n4", "n2", false),
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: null
+        shortestPaths: []
     },
     disconnectedComponents: {
         nodes: [
@@ -124,11 +168,11 @@ export const bfsShortestPath = {
             createNode("n3"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e1", "n1", "n2", false),
         ],
         sourceId: "n1",
         targetId: "n3",
-        expectedPath: null
+        shortestPaths: []
     },
     missingTarget: {
         nodes: [
@@ -137,12 +181,12 @@ export const bfsShortestPath = {
             createNode("n3"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-            createEdge("e2", "n1", "n3", false, 0.5),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n1", "n3", false),
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: null
+        shortestPaths: []
     },
     unknownSource: {
         nodes: [
@@ -151,12 +195,12 @@ export const bfsShortestPath = {
             createNode("n3"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-            createEdge("e2", "n1", "n3", false, 0.5),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n1", "n3", false),
         ],
         sourceId: "n4",
         targetId: "n1",
-        expectedPath: null
+        shortestPaths: []
     },
     bidirectionalEdges: {
         nodes: [
@@ -166,17 +210,16 @@ export const bfsShortestPath = {
             createNode("n4"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-            createEdge("e2", "n2", "n3", false, 0.6),
-            createEdge("e3", "n3", "n1", true, 0.7),
-            createEdge("e4", "n3", "n4", false, 0.8),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n2", "n3", false),
+            createEdge("e3", "n3", "n1", true),
+            createEdge("e4", "n3", "n4", false),
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n3", "n4"],
-            distance: 2
-        }
+        shortestPaths: [
+            {path: ["n1", "n3", "n4"],distance: 2}
+        ]
     },
     duplicateEdges: {
         nodes: [
@@ -186,18 +229,17 @@ export const bfsShortestPath = {
             createNode("n4"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", false, 0.5),
-            createEdge("e2", "n2", "n3", false, 0.6),
-            createEdge("e3", "n3", "n1", true, 0.7),
-            createEdge("e3", "n3", "n1", true, 0.7),
-            createEdge("e4", "n3", "n4", false, 0.8),
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n2", "n3", false),
+            createEdge("e3", "n3", "n1", true),
+            createEdge("e3", "n3", "n1", true),
+            createEdge("e4", "n3", "n4", false),
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n3", "n4"],
-            distance: 2
-        }
+        shortestPaths: [
+            {path: ["n1", "n3", "n4"],distance: 2}
+        ]
     },
     wideBranchingGraph: {
         nodes: [
@@ -212,21 +254,20 @@ export const bfsShortestPath = {
             createNode("n9"),
         ],
         edges: [
-            createEdge("e1", "n1", "n2", true, 0.5),
-            createEdge("e2", "n1", "n3", true, 0.6),
-            createEdge("e3", "n1", "n4", true, 0.7),
-            createEdge("e4", "n1", "n5", true, 0.8),
-            createEdge("e5", "n1", "n6", true, 0.8),
-            createEdge("e6", "n1", "n7", true, 0.8),
-            createEdge("e7", "n5", "n8", true, 0.8),
-            createEdge("e8", "n5", "n9", true, 0.8),
+            createEdge("e1", "n1", "n2", true),
+            createEdge("e2", "n1", "n3", true),
+            createEdge("e3", "n1", "n4", true),
+            createEdge("e4", "n1", "n5", true),
+            createEdge("e5", "n1", "n6", true),
+            createEdge("e6", "n1", "n7", true),
+            createEdge("e7", "n5", "n8", true),
+            createEdge("e8", "n5", "n9", true),
 
         ],
         sourceId: "n1",
         targetId: "n9",
-        expectedPath: {
-            path: ["n1", "n5", "n9"],
-            distance: 2
-        }
+        shortestPaths: [
+            {path: ["n1", "n5", "n9"],distance: 2}
+        ]
     }
 } satisfies Record<string, GraphShortestPathFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/bfsShortestPath.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/bfsShortestPath.fixtures.ts
@@ -1,0 +1,232 @@
+import { createNode, createEdge } from "../factories/index";
+import type { GraphShortestPathFixtureBody } from "../types";
+
+export const bfsShortestPath = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.1),
+            createEdge("e2", "n2", "n3", true, 0.2),
+            createEdge("e3", "n3", "n1", false, 0.3),
+            createEdge("e4", "n3", "n4", false, 0.4),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        expectedPath: {
+            path: ["n1", "n2", "n3"],
+            distance: 2
+        }
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n1",
+        expectedPath: {
+            path: ["n1"],
+            distance: 0
+        }
+    },
+    treePattern: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e2", "n2", "n5", false, 0.6),
+            createEdge("e4", "n3", "n4", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n2", "n3", "n4"],
+            distance: 3
+        }
+    },
+    multiplePaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.7),
+            createEdge("e4", "n1", "n5", false, 0.8),
+            createEdge("e5", "n5", "n4", false, 0.9),
+            createEdge("e6", "n5", "n2", false, 1.0),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n5", "n4"],
+            distance: 2
+        }
+    },
+    cyclicGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+            createEdge("e5", "n4", "n2", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n2", "n3", "n4"],
+            distance: 3
+        }
+    },
+    noPath: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n4", "n3", false, 0.8),
+            createEdge("e5", "n4", "n2", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: null
+    },
+    disconnectedComponents: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        expectedPath: null
+    },
+    missingTarget: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n1", "n3", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: null
+    },
+    unknownSource: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n1", "n3", false, 0.5),
+        ],
+        sourceId: "n4",
+        targetId: "n1",
+        expectedPath: null
+    },
+    bidirectionalEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n3", "n4"],
+            distance: 2
+        }
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n3", "n4"],
+            distance: 2
+        }
+    },
+    wideBranchingGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+            createNode("n8"),
+            createNode("n9"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+            createEdge("e2", "n1", "n3", true, 0.6),
+            createEdge("e3", "n1", "n4", true, 0.7),
+            createEdge("e4", "n1", "n5", true, 0.8),
+            createEdge("e5", "n1", "n6", true, 0.8),
+            createEdge("e6", "n1", "n7", true, 0.8),
+            createEdge("e7", "n5", "n8", true, 0.8),
+            createEdge("e8", "n5", "n9", true, 0.8),
+
+        ],
+        sourceId: "n1",
+        targetId: "n9",
+        expectedPath: {
+            path: ["n1", "n5", "n9"],
+            distance: 2
+        }
+    }
+} satisfies Record<string, GraphShortestPathFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/centrality.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/centrality.fixtures.ts
@@ -1,0 +1,231 @@
+import { createNode, createEdge } from "../factories/index";
+import type { CentralityFixtureBody } from "../types";
+
+export const centrality = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.1),
+            createEdge("e2", "n2", "n3", true, 0.2),
+            createEdge("e3", "n3", "n1", false, 0.3),
+            createEdge("e4", "n3", "n4", false, 0.4),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0.667],
+            ["n3", 0.667],
+            ["n4", 0],
+        ])
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        expectedResult: new Map<string, number>([
+            ["n1", 0]
+        ])
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0],
+        ])
+    },
+    noIntermediateNodes: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0],
+        ])
+    },
+    selfLoop: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n1", false, 0.5),
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0],
+        ])
+    },
+    treePattern: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e2", "n2", "n5", false, 0.6),
+            createEdge("e4", "n3", "n4", false, 0.7),
+            createEdge("e5", "n5", "n6", false, 0.7),
+            createEdge("e6", "n6", "n7", false, 0.7),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 1/3],
+            ["n3", 2/15],
+            ["n4", 0],
+            ["n5", 4/15],
+            ["n6", 1/5],
+            ["n7", 0],
+        ])
+    },
+    multipleShortestPaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n2", "n1", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n1", "n5", false, 0.5),
+            createEdge("e5", "n5", "n4", false, 0.8),
+            createEdge("e6", "n5", "n2", false, 0.0),
+            createEdge("e7", "n1", "n3", false, 0.0),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 1/6],
+            ["n2", 0],
+            ["n3", 1/6],
+            ["n4", 0],
+            ["n5", 1/3],
+        ])
+    },
+    disconnectedComponents: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.5),
+            createEdge("e3", "n3", "n1", false, 0.5),
+            createEdge("e4", "n4", "n3", false, 0.5),
+            createEdge("e5", "n5", "n6", false, 0.5),
+            createEdge("e6", "n6", "n7", false, 0.5),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 1/15],
+            ["n3", 0],
+            ["n4", 0],
+            ["n5", 0],
+            ["n6", 1/15],
+            ["n7", 0],
+        ])
+    },
+    bidirectionalEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0],
+            ["n3", 2/3],
+            ["n4", 0],
+        ])
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 0],
+            ["n2", 0],
+            ["n3", 2/3],
+            ["n4", 0],
+        ])
+    },
+    wideBranchingGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+            createNode("n8"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+            createEdge("e2", "n1", "n3", true, 0.6),
+            createEdge("e3", "n1", "n4", true, 0.7),
+            createEdge("e4", "n1", "n5", true, 0.8),
+            createEdge("e5", "n1", "n6", true, 0.8),
+            createEdge("e6", "n1", "n7", true, 0.8),
+            createEdge("e7", "n2", "n8", true, 0.8),
+            createEdge("e8", "n3", "n8", true, 0.8),
+            createEdge("e9", "n4", "n8", true, 0.8),
+            createEdge("e10", "n5", "n8", true, 0.8),
+            createEdge("e11", "n6", "n8", true, 0.8),
+            createEdge("e12", "n7", "n8", true, 0.8),
+
+        ],
+        expectedResult: new Map<string, number>([
+            ["n1", 15/21],
+            ["n2", 1/21],
+            ["n3", 0],
+            ["n4", 0],
+            ["n5", 0],
+            ["n6", 0],
+            ["n7", 0],
+            ["n8", 0],
+        ])
+    }
+} satisfies Record<string, CentralityFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/dijsktra.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/dijsktra.fixtures.ts
@@ -1,0 +1,232 @@
+import { createNode, createEdge } from "../factories/index";
+import type { GraphShortestPathFixtureBody } from "../types";
+
+export const dijkstra = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.1),
+            createEdge("e2", "n2", "n3", true, 0.2),
+            createEdge("e3", "n3", "n1", false, 0.3),
+            createEdge("e4", "n3", "n4", false, 0.4),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        expectedPath: {
+            path: ["n1", "n2", "n3"],
+            distance: 0.3
+        }
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n1",
+        expectedPath: {
+            path: ["n1"],
+            distance: 0
+        }
+    },
+    treePattern: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e2", "n2", "n5", false, 0.6),
+            createEdge("e4", "n3", "n4", false, 0.7),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n2", "n3", "n4"],
+            distance: 1.8
+        }
+    },
+    multiplePaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n1", "n5", false, 0.5),
+            createEdge("e5", "n5", "n4", false, 0.9),
+            createEdge("e6", "n5", "n2", false, 0.0),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n5", "n4"],
+            distance: 1.3
+        }
+    },
+    cyclicGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+            createEdge("e5", "n4", "n2", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n2", "n3", "n4"],
+            distance: 1.9
+        }
+    },
+    noPath: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n4", "n3", false, 0.8),
+            createEdge("e5", "n4", "n2", false, 0.9),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: null
+    },
+    disconnectedComponents: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        expectedPath: null
+    },
+    missingTarget: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n1", "n3", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: null
+    },
+    unknownSource: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n1", "n3", false, 0.5),
+        ],
+        sourceId: "n4",
+        targetId: "n1",
+        expectedPath: null
+    },
+    bidirectionalEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n3", "n4"],
+            distance: 1.5
+        }
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        expectedPath: {
+            path: ["n1", "n3", "n4"],
+            distance: 1.5
+        }
+    },
+    wideBranchingGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+            createNode("n8"),
+            createNode("n9"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+            createEdge("e2", "n1", "n3", true, 0.6),
+            createEdge("e3", "n1", "n4", true, 0.7),
+            createEdge("e4", "n1", "n5", true, 0.9),
+            createEdge("e5", "n1", "n6", true, 0.8),
+            createEdge("e6", "n1", "n7", true, 1.0),
+            createEdge("e7", "n5", "n8", true, 0.1),
+            createEdge("e8", "n5", "n9", true, 0.2),
+
+        ],
+        sourceId: "n1",
+        targetId: "n9",
+        expectedPath: {
+            path: ["n1", "n5", "n9"],
+            distance: 1.0
+        }
+    }
+} satisfies Record<string, GraphShortestPathFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/dijsktra.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/dijsktra.fixtures.ts
@@ -17,10 +17,9 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n3",
-        expectedPath: {
-            path: ["n1", "n2", "n3"],
-            distance: 0.3
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3"], distance: 0.3}
+        ]
     },
     singleNode: {
         nodes: [
@@ -29,10 +28,34 @@ export const dijkstra = {
         edges: [],
         sourceId: "n1",
         targetId: "n1",
-        expectedPath: {
-            path: ["n1"],
-            distance: 0
-        }
+        shortestPaths: [
+            {path: ["n1"], distance: 0}
+        ]
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n2",
+        shortestPaths: []
+    },
+    selfLoop: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n1", true, 0.5),
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        targetId: "n2",
+        shortestPaths: [
+            {path: ["n1", "n2"], distance: 0.5}
+        ]
     },
     treePattern: {
         nodes: [
@@ -50,10 +73,9 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n2", "n3", "n4"],
-            distance: 1.8
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3", "n4"], distance: 1.8}
+        ]
     },
     multiplePaths: {
         nodes: [
@@ -73,10 +95,32 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n5", "n4"],
-            distance: 1.3
-        }
+        shortestPaths: [
+            {path: ["n1", "n5", "n2", "n3", "n4"], distance: 1.3}
+        ]
+    },
+    multipleShortestPaths: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n4", false, 0.2),
+            createEdge("e4", "n1", "n5", false, 0.5),
+            createEdge("e5", "n5", "n4", false, 0.8),
+            createEdge("e6", "n5", "n2", false, 0.0),
+        ],
+        sourceId: "n1",
+        targetId: "n4",
+        shortestPaths: [
+            {path: ["n1", "n5", "n4"], distance: 1.3},
+            {path: ["n1", "n5", "n2", "n3", "n4"], distance: 1.3}
+        ]
     },
     cyclicGraph: {
         nodes: [
@@ -94,10 +138,9 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n2", "n3", "n4"],
-            distance: 1.9
-        }
+        shortestPaths: [
+            {path: ["n1", "n2", "n3", "n4"], distance: 1.9}
+        ]
     },
     noPath: {
         nodes: [
@@ -115,7 +158,7 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: null
+        shortestPaths: []
     },
     disconnectedComponents: {
         nodes: [
@@ -128,7 +171,7 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n3",
-        expectedPath: null
+        shortestPaths: []
     },
     missingTarget: {
         nodes: [
@@ -142,7 +185,7 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: null
+        shortestPaths: []
     },
     unknownSource: {
         nodes: [
@@ -156,7 +199,7 @@ export const dijkstra = {
         ],
         sourceId: "n4",
         targetId: "n1",
-        expectedPath: null
+        shortestPaths: []
     },
     bidirectionalEdges: {
         nodes: [
@@ -173,10 +216,9 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n3", "n4"],
-            distance: 1.5
-        }
+        shortestPaths: [
+            {path: ["n1", "n3", "n4"], distance: 1.5}
+        ]
     },
     duplicateEdges: {
         nodes: [
@@ -194,10 +236,9 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n4",
-        expectedPath: {
-            path: ["n1", "n3", "n4"],
-            distance: 1.5
-        }
+        shortestPaths: [
+            {path: ["n1", "n3", "n4"], distance: 1.5}
+        ]
     },
     wideBranchingGraph: {
         nodes: [
@@ -224,9 +265,8 @@ export const dijkstra = {
         ],
         sourceId: "n1",
         targetId: "n9",
-        expectedPath: {
-            path: ["n1", "n5", "n9"],
-            distance: 1.0
-        }
+        shortestPaths: [
+            {path: ["n1", "n5", "n9"], distance: 1.1}
+        ]
     }
 } satisfies Record<string, GraphShortestPathFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/graph.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/graph.ts
@@ -1,0 +1,31 @@
+import { GraphEdge, GraphNode } from "../../../types/index";
+import { createNode, createEdge } from "../factories/index";
+
+type AdjacencyMap = Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>;
+
+export const nodeSet0: GraphNode[] = [
+    createNode("1")
+];
+
+export const nodeSet1: GraphNode[] = [
+    createNode("n1"),
+    createNode("n2"),
+    createNode("n3"),
+];
+
+export const edgeSet1: GraphEdge[] = [
+    createEdge("e1", "n1", "n2", 0.5, true),
+    createEdge("e2", "n2", "n3", 0.5, false),
+    createEdge("e3", "n1", "n3", 0.7, false),
+];
+
+export const adjList1: AdjacencyMap = new Map();
+adjList1.set("n1", [
+    {nodeId: "n2", edgeId: "e1", weight: 0.5},
+    {nodeId: "n3", edgeId: "e3", weight: 0.7},
+]);
+adjList1.set("n2", [
+    {nodeId: "n1", edgeId: "e1", weight: 0.5},
+    {nodeId: "n3", edgeId: "e2", weight: 0.5},
+]);
+adjList1.set("n3", []);

--- a/packages/core/src/__tests__/testUtils/fixtures/graph.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/graph.ts
@@ -1,31 +1,183 @@
-import { GraphEdge, GraphNode } from "../../../types/index";
 import { createNode, createEdge } from "../factories/index";
+import type { AdjacencyFixtureBody, GraphShortestPathFixtureBody } from "../types";
 
-type AdjacencyMap = Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>;
+export const adjacency: Record<string, AdjacencyFixtureBody> = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.5),
+            createEdge("e3", "n1", "n3", false, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 0.5},
+                {nodeId: "n3", edgeId: "e3", weight: 1},
+            ]],
+            ["n2", [
+                {nodeId: "n1", edgeId: "e1", weight: 0.5},
+                {nodeId: "n3", edgeId: "e2", weight: 0.5},
+            ]],
+            ["n3", [
+    
+            ]]
+        ])
+    },
+    directional: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 0.5},
+            ]],
+            ["n2", [
+    
+            ]],
+        ])
+    },
+    biDirectional: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 0.5},
+            ]],
+            ["n2", [
+                {nodeId: "n1", edgeId: "e1", weight: 0.5},
+            ]],
+        ])
+    },
+    weight: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+            ]],
+            ["n2", [
+    
+            ]],
+        ])
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", []],
+            ["n2", []],
+        ])
+    },
+    unConnectedNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", []]
+        ])
+    },
+    unknownTarget: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n3", false, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n3", edgeId: "e1", weight: 0.5},
+            ]],
+            ["n2", []],
+        ])
+    },
+    unknownSource: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n3", "n1", false, 0.5),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", []],
+            ["n2", []],
+        ])
+    },
+    duplicateEdge: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e1", "n1", "n2", false),
+        ],
+        adjacencyList: new Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>([
+            ["n1", [
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+                {nodeId: "n2", edgeId: "e1", weight: 1},
+            ]],
+            ["n2", [
+    
+            ]],
+        ])
+    }
+};
 
-export const nodeSet0: GraphNode[] = [
-    createNode("1")
-];
-
-export const nodeSet1: GraphNode[] = [
-    createNode("n1"),
-    createNode("n2"),
-    createNode("n3"),
-];
-
-export const edgeSet1: GraphEdge[] = [
-    createEdge("e1", "n1", "n2", 0.5, true),
-    createEdge("e2", "n2", "n3", 0.5, false),
-    createEdge("e3", "n1", "n3", 0.7, false),
-];
-
-export const adjList1: AdjacencyMap = new Map();
-adjList1.set("n1", [
-    {nodeId: "n2", edgeId: "e1", weight: 0.5},
-    {nodeId: "n3", edgeId: "e3", weight: 0.7},
-]);
-adjList1.set("n2", [
-    {nodeId: "n1", edgeId: "e1", weight: 0.5},
-    {nodeId: "n3", edgeId: "e2", weight: 0.5},
-]);
-adjList1.set("n3", []);
+export const graphShortestPath: Record<string, GraphShortestPathFixtureBody> = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false),
+            createEdge("e2", "n2", "n3", false),
+            createEdge("e3", "n3", "n1", false),
+            createEdge("e4", "n3", "n4", false),
+        ],
+        sourceId: "n1",
+        targetId: "n3",
+        expectedPath: {
+            path: ["n1", "n2", "n3"],
+            distance: 2
+        }
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        targetId: "n1",
+        expectedPath: {
+            path: ["n1"],
+            distance: 0
+        }
+    },
+};

--- a/packages/core/src/__tests__/testUtils/fixtures/index.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/index.ts
@@ -2,4 +2,11 @@
 export { adjacency } from "./adjacency.fixtures";
 
 export { bfsShortestPath } from "./bfsShortestPath.fixtures";
+
 export { dijkstra } from "./dijsktra.fixtures";
+
+export { allPaths } from "./allPaths.fixtures";
+
+export { reachableNodes } from "./reachableNodes.fixtures";
+
+export{ centrality }  from "./centrality.fixtures";

--- a/packages/core/src/__tests__/testUtils/fixtures/index.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/index.ts
@@ -1,2 +1,5 @@
 
-export * from "./graph";
+export { adjacency } from "./adjacency.fixtures";
+
+export { bfsShortestPath } from "./bfsShortestPath.fixtures";
+export { dijkstra } from "./dijsktra.fixtures";

--- a/packages/core/src/__tests__/testUtils/fixtures/index.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/index.ts
@@ -1,0 +1,2 @@
+
+export * from "./graph";

--- a/packages/core/src/__tests__/testUtils/fixtures/reachableNodes.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/reachableNodes.fixtures.ts
@@ -1,0 +1,177 @@
+import { createNode, createEdge } from "../factories/index";
+import { ReachableNodesFixtureBody } from "../types";
+
+export const reachableNodes = {
+    general: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.1),
+            createEdge("e2", "n2", "n3", true, 0.2),
+            createEdge("e3", "n4", "n3", false, 0.3),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3"]
+    },
+    singleNode: {
+        nodes: [
+            createNode("n1"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        expectedNodes: []
+    },
+    noEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [],
+        sourceId: "n1",
+        expectedNodes: []
+    },
+    selfLoop: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n1", true, 0.5),
+            createEdge("e2", "n1", "n2", false, 0.5),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2"]
+    },
+    treePattern: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e2", "n2", "n5", false, 0.6),
+            createEdge("e4", "n3", "n4", false, 0.7),
+            createEdge("e5", "n5", "n6", false, 0.7),
+            createEdge("e6", "n5", "n7", false, 0.7),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3", "n4", "n5", "n6", "n7"]
+    },
+    disconnectedComponents: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n4", "n3", false, 0.8),
+            createEdge("e5", "n5", "n6", false, 0.9),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3"]
+    },
+    unknownSource: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+        ],
+        sourceId: "n4",
+        expectedNodes: []
+    },
+    bidirectionalEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 1.0),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e4", "n4", "n3", true, 0.5),
+            createEdge("e5", "n5", "n4", true, 0.9),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3", "n4", "n5"]
+    },
+    absentSourceFromNodes: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", false, 0.7),
+            createEdge("e4", "n3", "n4", true, 0.7),
+        ],
+        sourceId: "n4",
+        expectedNodes: []
+    },
+    duplicateEdges: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", false, 0.5),
+            createEdge("e2", "n2", "n3", false, 0.6),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e3", "n3", "n1", true, 0.7),
+            createEdge("e4", "n3", "n4", false, 0.8),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3", "n4"]
+    },
+    cyclicGraph: {
+        nodes: [
+            createNode("n1"),
+            createNode("n2"),
+            createNode("n3"),
+            createNode("n4"),
+            createNode("n5"),
+            createNode("n6"),
+            createNode("n7"),
+        ],
+        edges: [
+            createEdge("e1", "n1", "n2", true, 1.0),
+            createEdge("e2", "n3", "n2", true, 0.6),
+            createEdge("e3", "n3", "n4", true, 0.2),
+            createEdge("e4", "n2", "n4", false, 0.5),
+            createEdge("e5", "n6", "n5", false, 0.6),
+            createEdge("e6", "n3", "n5", true, 0.7),
+            createEdge("e7", "n1", "n6", false, 0.8),
+            createEdge("e8", "n6", "n3", false, 0.9),
+            createEdge("e9", "n5", "n7", false, 0.9),
+            createEdge("e10", "n7", "n4", false, 1.0),
+        ],
+        sourceId: "n1",
+        expectedNodes: ["n2", "n3", "n4", "n5", "n6", "n7"]
+    },
+} satisfies Record<string, ReachableNodesFixtureBody>;

--- a/packages/core/src/__tests__/testUtils/fixtures/reachableNodes.fixtures.ts
+++ b/packages/core/src/__tests__/testUtils/fixtures/reachableNodes.fixtures.ts
@@ -1,5 +1,5 @@
 import { createNode, createEdge } from "../factories/index";
-import { ReachableNodesFixtureBody } from "../types";
+import type { ReachableNodesFixtureBody } from "../types";
 
 export const reachableNodes = {
     general: {

--- a/packages/core/src/__tests__/testUtils/index.ts
+++ b/packages/core/src/__tests__/testUtils/index.ts
@@ -1,0 +1,4 @@
+
+export * from "./fixtures/index";
+
+export * from "./factories/index";

--- a/packages/core/src/__tests__/testUtils/types/index.ts
+++ b/packages/core/src/__tests__/testUtils/types/index.ts
@@ -1,4 +1,4 @@
-import { GraphEdge, GraphNode, PathResult } from "../../../types/index";
+import type { GraphEdge, GraphNode, PathResult } from "../../../types/index";
 
 export type AdjacencyMap = Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>;
 
@@ -21,8 +21,8 @@ export interface AllPathsFixtureBody {
     edges: GraphEdge[];
     sourceId: string;
     targetId: string;
-    maxPaths: Number;
-    maxDepth: Number;
+    maxPaths: number;
+    maxDepth: number;
     expectedPaths: PathResult[];
 }
 

--- a/packages/core/src/__tests__/testUtils/types/index.ts
+++ b/packages/core/src/__tests__/testUtils/types/index.ts
@@ -13,5 +13,5 @@ export interface GraphShortestPathFixtureBody {
     edges: GraphEdge[];
     sourceId: string;
     targetId: string;
-    expectedPath: PathResult;
+    expectedPath: PathResult | null;
 }

--- a/packages/core/src/__tests__/testUtils/types/index.ts
+++ b/packages/core/src/__tests__/testUtils/types/index.ts
@@ -1,0 +1,17 @@
+import { GraphEdge, GraphNode, PathResult } from "../../../types/index";
+
+export type AdjacencyMap = Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>;
+
+export interface AdjacencyFixtureBody {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    adjacencyList: AdjacencyMap;
+}
+
+export interface GraphShortestPathFixtureBody {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    sourceId: string;
+    targetId: string;
+    expectedPath: PathResult;
+}

--- a/packages/core/src/__tests__/testUtils/types/index.ts
+++ b/packages/core/src/__tests__/testUtils/types/index.ts
@@ -13,5 +13,28 @@ export interface GraphShortestPathFixtureBody {
     edges: GraphEdge[];
     sourceId: string;
     targetId: string;
-    expectedPath: PathResult | null;
+    shortestPaths: PathResult[];
+}
+
+export interface AllPathsFixtureBody {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    sourceId: string;
+    targetId: string;
+    maxPaths: Number;
+    maxDepth: Number;
+    expectedPaths: PathResult[];
+}
+
+export interface ReachableNodesFixtureBody {
+    nodes: GraphNode[];
+    edges:GraphEdge[];
+    sourceId: string;
+    expectedNodes: string[];
+}
+
+export interface CentralityFixtureBody {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    expectedResult: Map<string, number>;
 }

--- a/packages/core/src/algorithms/pathfinding.ts
+++ b/packages/core/src/algorithms/pathfinding.ts
@@ -2,7 +2,7 @@ import type { GraphNode, GraphEdge, PathResult } from '../types/index.js';
 
 type AdjacencyMap = Map<string, Array<{ nodeId: string; edgeId: string; weight: number }>>;
 
-function buildAdjacency(nodes: GraphNode[], edges: GraphEdge[]): AdjacencyMap {
+export function buildAdjacency(nodes: GraphNode[], edges: GraphEdge[]): AdjacencyMap {
   const adj: AdjacencyMap = new Map();
   for (const node of nodes) adj.set(node.id, []);
 

--- a/packages/core/tsconfig.eslint.json
+++ b/packages/core/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+      "src/**/*.ts",
+      "src/**/*.tsx"
+    ],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
       provider: "v8",
 
       // Measure coverage for the source code
-      include: ["src/**/*.ts"],
+      include: ["src/algorithms/pathfinding.ts"],
 
       // Reports
       reporter: ["text", "html"],

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+
+      // Measure coverage for the source code
+      include: ["src/**/*.ts"],
+
+      // Reports
+      reporter: ["text", "html"],
+
+      // CI fails if coverage drops below 80%
+      thresholds: {
+        lines: 80
+      }
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.37
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -120,6 +123,14 @@ packages:
 
   /@adobe/css-tools@4.4.4:
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+    dev: true
+
+  /@ampproject/remapping@2.3.0:
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
     dev: true
 
   /@asamuzakjp/css-color@3.2.0:
@@ -311,6 +322,10 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+    dev: true
+
+  /@bcoe/v8-coverage@0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
   /@csstools/color-helpers@5.1.0:
@@ -620,6 +635,11 @@ packages:
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+    dev: true
+
+  /@istanbuljs/schema@0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
     dev: true
 
   /@jest/schemas@29.6.3:
@@ -1151,6 +1171,29 @@ packages:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.21(@types/node@20.19.37)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/coverage-v8@1.6.1(vitest@1.6.1):
+    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+    peerDependencies:
+      vitest: 1.6.1
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@20.19.37)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2324,6 +2367,10 @@ packages:
       whatwg-encoding: 3.1.1
     dev: true
 
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2613,6 +2660,39 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2773,6 +2853,21 @@ packages:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+    dev: true
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.7.4
     dev: true
 
   /math-intrinsics@1.1.0:
@@ -3580,6 +3675,15 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.5
     dev: true
 
   /text-table@0.2.0:


### PR DESCRIPTION
## Summary

Added comprehensive test cases for the pathfinding module to achieve 100% line coverage.

## Type of Change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Performance improvement (`perf`)
- [ ] Refactor — no behaviour change (`refactor`)
- [ ] Documentation (`docs`)
- [x] Tests (`test`)
- [ ] Tooling / deps (`chore`)

## Related Issue

Part of #10 

## Changes

- Covered all execution paths including edge cases
- Added behavioral testing to safeguard current behavior against future modifications
- Added `vitest.config.ts` with coverage configuration
- Set up minimum coverage threshold for CI (80% minimum coverage)

## Test Plan

- [x] Added unit tests
- [ ] Added integration tests
- [x] Manually tested locally
- [ ] Existing tests cover this change

## Checklist

- [ ] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows [Conventional Commits](../CONTRIBUTING.md#commit-message-format) format
- [x] Docs updated if needed (README, CONTRIBUTING)
- [x] No `any` types introduced
- [x] No secrets or `.env` files committed

### Note

- Typecheck, test and build checks passes for `@synapse/core` package. Lint fails due to missing parserOptions.project configuration required by @typescript-eslint rules, which is unrelated to this PR.

## Observations

- Duplicate edges are allowed and preserved in `buildAdjacency` function's output.
- `findAllPaths` function returns duplicate paths if duplicate edges are present in graph.
- `betweennessCentrality` function is biased towards BFS result as it only considers centrality contribution from only one of all possible shortest paths.
